### PR TITLE
Add API endpoint for OAuth2 clients by name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,10 @@ services:
       - './test/support:/usr/app/test/support'
     environment:
       - 'REDIS_HOST=redis'
-      - 'POSTGRES_URL=postgres://postgres:secret@postgres/ripple_auth'
+      - 'POSTGRES_HOST=postgres'
+      - 'POSTGRES_USERNAME=postgres'
+      - 'POSTGRES_PASSWORD=secret'
+      - 'POSTGRES_DATABASE=ripple_auth'
       - 'COOKIE_SECRET=secret'
       - 'PUBLIC_DOMAIN'
       - 'MAILGUN_API_KEY'

--- a/src/controllers/api/oauth2-clients-controller.ts
+++ b/src/controllers/api/oauth2-clients-controller.ts
@@ -1,0 +1,17 @@
+import { JsonController, Get, Param, NotFoundError } from 'routing-controllers';
+import OAuth2ClientService from '../../services/oauth2-client-service';
+
+@JsonController('/api/oauth2/clients')
+export class OAuth2ClientController {
+  @Get('/:clientName')
+  async getClient(@Param('clientName') clientName: string) {
+    const client = await OAuth2ClientService.findByName(clientName);
+    if (!client) {
+      throw new NotFoundError('Client not found');
+    }
+    return {
+      id: client.id,
+      name: client.name
+    };
+  }
+}

--- a/src/services/oauth2-client-service.ts
+++ b/src/services/oauth2-client-service.ts
@@ -22,6 +22,10 @@ class OAuthClientService {
   findById(id: string) {
     return OAuth2Client.findOne({ where: { id } });
   }
+
+  findByName(name: string) {
+    return OAuth2Client.findOne({ where: { name } });
+  }
 }
 
 export default new OAuthClientService();


### PR DESCRIPTION
* You can now fetch OAuth2 clients by name via the `/api/oauth2/clients/:clientName` endpoint.