### PR TITLE
UUID columns now use pgcrypto to generate uuids

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-auth",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "index.js",
   "author": "Daniel <danielrudn@gmail.com>",
   "license": "MIT",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,7 +4,7 @@ import OAuth2ClientService from '../services/oauth2-client-service';
 
 (async () => {
   const connection = await initDB();
-  program.version('0.1.1', '-v, --version');
+  program.version('0.1.2', '-v, --version');
 
   program
     .command('migrate')

--- a/src/migrations/1542315396947-create_users.ts
+++ b/src/migrations/1542315396947-create_users.ts
@@ -2,6 +2,7 @@ import { MigrationInterface, QueryRunner, Table } from 'typeorm';
 
 export class create_users1542315396947 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
     await queryRunner.createTable(
       new Table({
         name: 'users',
@@ -10,7 +11,7 @@ export class create_users1542315396947 implements MigrationInterface {
             name: 'id',
             type: 'uuid',
             isPrimary: true,
-            default: 'uuid_generate_v4()'
+            default: 'gen_random_uuid()'
           },
           {
             name: 'username',
@@ -44,5 +45,6 @@ export class create_users1542315396947 implements MigrationInterface {
 
   public async down(queryRunner: QueryRunner): Promise<any> {
     await queryRunner.dropTable('users');
+    await queryRunner.query('DROP EXTENSION pgcrypto');
   }
 }

--- a/src/migrations/1542323994373-create_access_tokens.ts
+++ b/src/migrations/1542323994373-create_access_tokens.ts
@@ -15,7 +15,7 @@ export class createAccessTokens1542323994373 implements MigrationInterface {
             name: 'id',
             type: 'uuid',
             isPrimary: true,
-            default: 'uuid_generate_v4()'
+            default: 'gen_random_uuid()'
           },
           {
             name: 'token',

--- a/src/migrations/1542325237092-create_oauth2_clients.ts
+++ b/src/migrations/1542325237092-create_oauth2_clients.ts
@@ -16,7 +16,7 @@ export class createOauth2Clients1542325237092 implements MigrationInterface {
             name: 'id',
             type: 'uuid',
             isPrimary: true,
-            default: 'uuid_generate_v4()'
+            default: 'gen_random_uuid()'
           },
           {
             name: 'client_secret',


### PR DESCRIPTION
* pgcrypto is now installed if necessary and columns using uuids now use the `gen_random_uuid()` function from pgcrypto.