### PR TITLE
Log http errors and fix duplicate oauth2 clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.3] - 2019-02-26
+
+### Changed
+
+* Errors that result in an HTTP 500 response are now logged to console
+* `createOAuth2Client` CLI command now fails if a client with that name already exists
+
+## [0.1.2] - 2019-02-20
+
+### Changed
+
+* UUID columns types are changed to use the `gen_random_uuid()` function defined in the `pgcrypto` extension to generate uuids instead of `uuid_generate_v4()`
+
+## [0.1.1] - 2019-02-16
+
+### Added
+
+* Add endpoint to retrieve OAuth2 client id by client name (useful for `web` service not needing to know `client_id` ahead of time)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,98 @@
+# ripple.fm auth service
+
+Authentication and user service for ripple.fm
+
+Acts as an OAuth2 provider for the ripple.fm web client and exposes REST API endpoints for user data.
+
+## Table of Contents
+
+* [Prerequisites](#prerequisites)
+* [Technologies](#technologies)
+* [Development](#development)
+  * [Formatting](#formatting)
+  * [Setting up your environment](#setting-up-your-environment)
+  * [Starting the service](#starting-the-service)
+* [Production](#production)
+  * [Deploying](#deploying)
+  * [Notes on configuration](#notes-on-configuration)
+  * [CLI](#cli)
+
+# Prerequisites
+
+* yarn or npm
+* Typescript
+* docker and docker-compose
+
+# Technologies
+
+This project was built with:
+
+* [Typescript](https://www.typescriptlang.org/)
+* [express](https://expressjs.com/) + [routing-controllers](https://github.com/typestack/routing-controllers) for controllers
+* [oauth2orize](https://github.com/jaredhanson/oauth2orize)
+* [TypeORM](https://github.com/typeorm/typeorm)
+* [webpack](https://webpack.js.org/) for bundling/transpiling sass and es6
+* [pug](https://pugjs.org/api/getting-started.html) for templating html and [MJML](https://mjml.io/) for templating emails
+
+# Development
+
+## Formatting
+
+This project uses [Prettier](https://github.com/prettier/prettier) for formatting. It's recommended to configure your editor to work with prettier using the [editor integrations](https://prettier.io/docs/en/editors.html).
+
+Formatting is checked when Travis CI runs a build and can be checked locally using the one of the following commands:
+
+```sh
+yarn lint
+```
+
+or
+
+```sh
+npm run lint
+```
+
+## Setting up your environment
+
+We must first set the environment variables defined in [.env.example](.env.example). The variables include comments and are marked optional. **NOTE**: Some variables are not required to run the basic development environment.
+
+The steps for defining your environment variables:
+
+1. Copy `.env.exmaple` to `.env`
+1. Update values for the variables
+1. Source the environment using `source .env`
+
+## Starting the service
+
+Now that we loaded the environment variables we can start the service using `docker-compose`
+
+To start we run:
+
+```sh
+$ docker-compose up
+```
+
+To stop:
+
+```sh
+$ docker-compose down
+```
+
+# Production
+
+## Deploying
+
+Travis CI will automatically build and push tagged commits (matching the version in `package.json`) to the docker image repository.
+
+After an image is built and pushed, update the [helm chart for ripple.fm](https://github.com/ripplefm/charts) to set the updated tag for the auth service.
+
+## Notes on configuration
+
+Some notes about deploying to production:
+
+* Ensure `NODE_ENV` is set to `production`
+* the `REDIS_PASSOWRD` environment variable is optional but recommended
+
+## CLI
+
+The auth service includes cli commands defined [here](src/cli/index.ts). These commands can be used to initialize our service (i.e running migrations or creating oauth2 clients).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-auth",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "index.js",
   "author": "Daniel <danielrudn@gmail.com>",
   "license": "MIT",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,7 +4,7 @@ import OAuth2ClientService from '../services/oauth2-client-service';
 
 (async () => {
   const connection = await initDB();
-  program.version('0.1.2', '-v, --version');
+  program.version('0.1.3', '-v, --version');
 
   program
     .command('migrate')
@@ -15,13 +15,22 @@ import OAuth2ClientService from '../services/oauth2-client-service';
     .option('-t, --trusted', 'Whether or not this client is trusted')
     .action(async (name, redirectUris, cmd) => {
       try {
-        const client = await OAuth2ClientService.create(
-          name,
-          'default description',
-          redirectUris,
-          cmd.trusted
-        );
-        console.log('Successfully created client:', client);
+        const existing = await OAuth2ClientService.findByName(name);
+        if (existing === undefined) {
+          const client = await OAuth2ClientService.create(
+            name,
+            'default description',
+            redirectUris,
+            cmd.trusted
+          );
+          console.log('Successfully created client:', client);
+        } else {
+          throw new Error(
+            `Client with name "${name}" already exists: ${JSON.stringify(
+              existing
+            )}`
+          );
+        }
       } catch (err) {
         console.error('Error creating client:', err);
       }

--- a/src/middleware/error-middleware.ts
+++ b/src/middleware/error-middleware.ts
@@ -46,6 +46,8 @@ export function errorMiddleware(
     } else if (err instanceof HttpError) {
       return res.status(err.httpCode).json({ error: err.message });
     } else {
+      console.error('Uncaught exception. HTTP 500');
+      console.error(err);
       return res.status(500).send('Unknown error occurred.');
     }
   }


### PR DESCRIPTION
### Changed

* Errors that result in an HTTP 500 response are now logged to console
* `createOAuth2Client` CLI command now fails if a client with that name already exists