### PR TITLE
Fix iframe options and token issuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2019-03-01
+
+### Changed
+
+* Tokens are now signed with static issuer `ripple.fm` instead of signing with environment variable provided in `PUBLIC_DOMAIN`
+* Configured `helmet` and `frameguard` to allow iframe embedding on domain provided in environment variable `PUBLIC_DOMAIN`
+
 ## [0.1.3] - 2019-02-26
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-auth",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "index.js",
   "author": "Daniel <danielrudn@gmail.com>",
   "license": "MIT",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,7 +4,7 @@ import OAuth2ClientService from '../services/oauth2-client-service';
 
 (async () => {
   const connection = await initDB();
-  program.version('0.1.3', '-v, --version');
+  program.version('0.1.4', '-v, --version');
 
   program
     .command('migrate')

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,14 @@ const app = express();
 app.set('view engine', 'pug');
 
 app.use(express.static(path.join(__dirname, 'public')));
-app.use(helmet());
+app.use(
+  helmet({
+    frameguard: {
+      action: 'allow-from',
+      domain: process.env.PUBLIC_DOMAIN
+    }
+  })
+);
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(
   session({

--- a/src/services/token-service.ts
+++ b/src/services/token-service.ts
@@ -8,19 +8,17 @@ import { User } from '../entities/user';
 class TokenService {
   private cert: Buffer;
   private public_cert: Buffer;
-  private public_domain: string;
 
   constructor() {
     this.cert = readFileSync(process.env.PRIVATE_KEY_LOCATION);
     this.public_cert = readFileSync(process.env.PUBLIC_KEY_LOCATION);
-    this.public_domain = process.env.PUBLIC_DOMAIN;
   }
 
   verify(token: string): TokenClaims | undefined {
     try {
       return jwt.verify(token, this.public_cert, {
         algorithms: ['RS256'],
-        issuer: this.public_domain,
+        issuer: 'ripple.fm',
         maxAge: '30m'
       }) as TokenClaims;
     } catch (err) {
@@ -49,7 +47,7 @@ class TokenService {
       {
         algorithm: 'RS256',
         expiresIn: '30m',
-        issuer: this.public_domain,
+        issuer: 'ripple.fm',
         audience: client.id
       }
     );


### PR DESCRIPTION
### Changed

* Tokens are now signed with static issuer `ripple.fm` instead of signing with environment variable provided in `PUBLIC_DOMAIN`
* Configured `helmet` and `frameguard` to allow iframe embedding on domain provided in environment variable `PUBLIC_DOMAIN`