### PR TITLE
Add Content-Security-Policy header for iframe embeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2019-03-24
+
+### Fixed
+
+* Add `Content-Security-Policy` header with `PUBLIC_DOMAIN` as frame-ancestor to allow iframes to be embedded on `PUBLIC_DOMAIN`
+
 ## [0.2.1] - 2019-03-20
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple-auth",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "index.js",
   "author": "Daniel <danielrudn@gmail.com>",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,11 @@ app.set('view engine', 'pug');
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(
   helmet({
+    contentSecurityPolicy: {
+      directives: {
+        frameAncestors: [process.env.PUBLIC_DOMAIN]
+      }
+    },
     frameguard: {
       action: 'allow-from',
       domain: process.env.PUBLIC_DOMAIN


### PR DESCRIPTION
### Fixed

* Add `Content-Security-Policy` header with `PUBLIC_DOMAIN` as frame-ancestor to allow iframes to be embedded on `PUBLIC_DOMAIN`